### PR TITLE
Correct typo in SUGADD command

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function addRediSearchModule(redis) {
   redis.addCommand('ft.del');
   redis.addCommand('ft.drop');
   redis.addCommand('ft.optimize');
-  redis.addCommand('ft.suggadd');
+  redis.addCommand('ft.sugadd');
   redis.addCommand('ft.sugget');
   redis.addCommand('ft.sugdel');
   redis.addCommand('ft.suglen');


### PR DESCRIPTION
The command 'ft.sugadd' has a typo and is added 'ft.suggadd' causing a runtime error.  this PR resolves that.